### PR TITLE
feat:refresh_token_Reissue

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import { create } from 'superstruct';
 import { createUserBodyStruct, loginBodyStruct } from '../structs/userStruct';
-import { createUserService, loginUserService } from '../services/authService';
+import { createUserService, loginUserService, refreshToken } from '../services/authService';
+import { AuthenticatedRequest } from '../types/express';
 
 export const createUser = async (req: Request, res: Response) => {
   const user = create(req.body, createUserBodyStruct);
@@ -13,6 +14,13 @@ export const createUser = async (req: Request, res: Response) => {
 export const loginUser = async (req: Request, res: Response) => {
   const user = create(req.body, loginBodyStruct);
   const result = await loginUserService(user);
+
+  res.status(200).json(result);
+};
+
+export const refreshTokenUser = async (req: AuthenticatedRequest, res: Response) => {
+  const { userId } = req.user;
+  const result = await refreshToken(userId);
 
   res.status(200).json(result);
 };

--- a/src/dto/authDto.ts
+++ b/src/dto/authDto.ts
@@ -18,7 +18,7 @@ export class createUserResponseDTO {
   }
 }
 
-export class LoginUserResponsDTO {
+export class tokenResponsDTO {
   accessToken: string;
   refreshToken: string;
 

--- a/src/lib/async-handler.ts
+++ b/src/lib/async-handler.ts
@@ -1,11 +1,11 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 
-export function asyncHandler(
-  handler: (req: Request, res: Response, next: NextFunction) => Promise<void>,
+export function asyncHandler<TReq extends Request = Request>(
+  handler: (req: TReq, res: Response, next: NextFunction) => Promise<void>,
 ): RequestHandler {
   return async function (req: Request, res: Response, next: NextFunction) {
     try {
-      await handler(req, res, next);
+      await handler(req as TReq, res, next);
     } catch (e) {
       next(e);
     }

--- a/src/middlewares/verifyRefreshToken.ts
+++ b/src/middlewares/verifyRefreshToken.ts
@@ -6,5 +6,9 @@ export const verifyRefreshToken = expressjwt({
   secret: jwtSecret as Secret,
   algorithms: ['HS256'],
   requestProperty: 'user',
-  getToken: (req) => req.body.refresh,
+  getToken: (req) => {
+    const authHeader = req.headers.authorization;
+    const token = authHeader?.split(' ')[1];
+    return token;
+  },
 });

--- a/src/routers/authRouter.ts
+++ b/src/routers/authRouter.ts
@@ -1,7 +1,9 @@
 import express from 'express';
-import { createUser, loginUser } from '../controllers/authController';
+import { createUser, loginUser, refreshTokenUser } from '../controllers/authController';
 import { asyncHandler } from '../lib/async-handler';
+import { verifyRefreshToken } from '../middlewares/verifyRefreshToken';
 export const authRouter = express.Router();
 
 authRouter.post('/register', asyncHandler(createUser));
 authRouter.post('/login', asyncHandler(loginUser));
+authRouter.post('/refresh', verifyRefreshToken, asyncHandler(refreshTokenUser));

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -2,7 +2,7 @@ import { hashPassword } from '../lib/auth/hash';
 import BadRequestError from '../lib/errors/badRequestError';
 import { createUserRepositroy, matchEmail, saveRefreshToken } from '../repositories/authrepository';
 import { userLoginType, userInput } from '../types/authType';
-import { createUserResponseDTO, LoginUserResponsDTO } from '../dto/authDto';
+import { createUserResponseDTO, tokenResponsDTO } from '../dto/authDto';
 import NotFoundError from '../lib/errors/notFoundError';
 import bcrypt from 'bcrypt';
 import { createToken } from '../lib/auth/jwt';
@@ -48,7 +48,7 @@ export const loginUserService = async (user: userLoginType) => {
 
   const tokens = await createTokens(userId);
 
-  return new LoginUserResponsDTO(tokens);
+  return new tokenResponsDTO(tokens);
 };
 
 const createTokens = async (
@@ -59,4 +59,12 @@ const createTokens = async (
   await saveRefreshToken(refreshToken, userId);
 
   return { accessToken, refreshToken };
+};
+
+export const refreshToken = async (
+  id: number,
+): Promise<{ accessToken: string; refreshToken: string }> => {
+  const tokens = await createTokens(id);
+
+  return new tokenResponsDTO(tokens);
 };

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,16 @@
+import Express from 'express';
+import { Request } from 'express';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: {
+        userId: number;
+      };
+    }
+  }
+}
+
+export type AuthenticatedRequest<T extends Request = Request> = T & {
+  user: { userId: number };
+};


### PR DESCRIPTION
#18 

파일 수정: auth-controller.router,service
errController,verifyrefreshToken

파일 생성: express.d.ts

- 중급 프로젝트 때와 다르게 토큰을 body가 아닌 헤더로 보냄 
- 리프래시 토큰 검증을 미들웨어에서 진행
- 커스텀 error 핸들러 수정

```
### 토큰 재발급
POST http://localhost:3000/auth/refresh
Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VySWQiOjEsImlhdCI6MTc0NzIzNzgxMiwiZXhwIjoxNzQ3MjQxNDEyfQ.B2fxrlmYJsdU3Gv1dVqyHlNWDY91QL8CgkQt6-Yrk0g
```

